### PR TITLE
draft: ccgate を Zenn で紹介する記事を追加

### DIFF
--- a/articles/20260423-ccgate.md
+++ b/articles/20260423-ccgate.md
@@ -7,5 +7,67 @@ published: false
 publication_name: layerx
 ---
 
-こんにちは。[@tak848](https://github.com/tak848)です。
+## はじめに
 
+こんにちは。[@tak848](https://github.com/tak848)です。
+みなさん、Coding Agentは使っていますか？個人的には個人でも業務でもClaude Code・Codex CLIと合わせて欠かせないツールになっています。
+
+では、みなさん、Coding Agentが実行するToolのPermission管理はどうしていますか？
+基本的にAllow/Deny Listに登録していますか？ただ、&&, ||や$()などを組み合わせたり（要確認）、もはやシェル芸をAgentがし始めると、Claude Codeの解析器（要名称確認）がAllow List, Deny Listに一致したコマンドの組み合わせだけだとしても、安全のため人間へのPermission許可を求めてくることがあります。
+では、面倒だからDangerously Approveしていないですか？ここ数ヶ月でさまざまなセキュリティインシデントを見かける中で、何のハーネスも無く各toolを実行させるのは怖すぎる気がします。
+3月にClaude CodeではPermission 許可を
+
+
+<!-- みなさん、Coding Agentは使っていますか？この記事を読んでいる多くの人が使っているのでは無いかなと思います。
+色々な開発手法・ツールが出ていると思います。
+では、指示以外に何か困ることありませんか？
+Dangerously Approveをしている？ -->
+
+## きっかけ
+
+
+もともと、このツールを作ったきっかけは、Claude CodeのAuto Modeが出たことがきっかけでした。ただ、Auto Modeは半日ほど使えるようになったタイミングで、急に業務が高速に進むようになり、感動した記憶があります。
+ただ、すぐに使えなくなってしまい、またPermission許可の嵐に舞い戻されてしまい、なんで使えなくなったんだろう...と思っていました。
+
+しばらく経って、Teamなどの一部のPlanのユーザーに解禁されたとの情報が出ましたが、自身が使用しているMaxやEnterpriseでは依然として使えないままで、これずっと使えないままでは...となりました。
+Auto Modeは調べると、ざっくり言うと、Deny/Allow Listの判定で判定しきれなかったコマンドを、第三者としてのAIがjudgeを行いハンドリングするモードとわかりました。
+そこで、もしかして、前からあるHookの機能を使えば、自分でAuto Modeを作れてしまうのでは？と思い、自身のdotfiles上に実装してみたところ、幸せになりました。
+https://github.com/tak848/dotfiles/pull/512
+
+ちょっと使っているうちに、これは便利だとすぐ気づき、社内の技術書典の執筆期限が迫る中で、このHITLを自動化するAuto Modeの思想から、このPermissionHookを実装してみた話を書き上げ、そのタイミングでPermission Hookとして切り出したのがccgateというツールになります。
+https://github.com/tak848/ccgate
+
+Auto Modeと、作成当時のpermission hookによる自動許可ツールの設計思想は、先日の技術書典20で出版したLayerX Tech Book Vol.2の中で詳しく解説しています。よければこちらも是非ご覧ください。
+https://techbookfest.org/event/tbf20
+
+
+## Auto Modeとは何が違うのか
+
+Auto Modeは、Claude Codeの動作
+
+
+
+
+
+
+
+
+
+
+-----------------
+
+* 原点は、permission許可/拒否ばっかしてて、なんか生産性がすごく低い。特に放置して戻ってきたときに全然進まず止まっているとげんなりする。思い返すと、代替、シェル芸してきて安全に倒してPermission許可求めてくるケース、worktree跨いで検索し始めて、無限にPermission許可求めてくるケース、allowにもdenyにもそもそも入れていない、db操作を直接行おうとしてくるなどの、AIが本来のプロジェクトに用意・定義されたtask runnerを回せばよいのに迷子になっているケースなど色々ある。そのたびに、このworktreeを調べれば良いじゃん何でもとのほうみにいくの？とか、make/task/mise runとか, pnpm runとかすれば良いよ？みたいな同じようなコメントしたりsuru
+* そして、githubのread系のコマンドは基本自動許可しているものの、gh apiとかみたいなコマンドはallow listに入れて許可は決してしたくない。また他にも、draft PR作成以外は許可したくない、とかもある。github mcpを使うように指示してから、review comment取得とかはmcp経由でallow listに入れると言った回避は出来るようになったが、ghじゃないとできないことも多く、そうすると、allowにも入れず, denyにも入れずで、permission地獄がスタートする。ただ、本来ちゃんとcommandを見れば判断は簡単にできるはず。
+* plan modeなどでのExplore Agentが、高度なシェル芸（$()や&&, ||など）を駆使してコードベースを検索してくるせいで、Claude Codeの解析器が、Allow/Deny Listに登録しているコマンドの組み合わせだけだとしても、Permission許可を求めてくることがある。さらに、そもそも/path/to/reponame-worktree1のような環境で作業しているのに、/path/to/reponameのような本repositoryのパスを検索し始めて、無限にPermission許可を求めてくることがある。
+* 意図しないツール操作をし始める（npx, db操作、プロジェクト定義のtaskを使わない独自コマンド実行、意味も無くcdしてから各操作をしてくるなど）。そもそもallowにもdenyにも登録していないので結果的にPermission許可を求めてきては、同じようなコメントで拒否している
+であれば、その辺を言語化してLLMに判断させて自動で返信させればええやん。少なくとも、作業履行で頭いっぱいのAgentと違って、第三者のLLM callとして呼べば、冷静かつ無慈悲にdenyはしてくれるし、messageも付与して、agentへの理解も促すことができるやん。
+* Auto Mode使えるようになってくれや。ruleを自分でも設定できるみたいだし。
+    * （ここ最近の出来事）祝Opus4.7リリース&Auto Mode全解禁！となったものの、これModeとして独立している以上、PlanではPermission地獄から全く抜け出していない。しかも、Auto Modeもruleは設定できるし、というかccgateはもともとauto mode辺りから着想を得て作ったし、カスタマイズもできるが、environmentはなんかdotfiles管理するには絶妙にめんどくさいし、どういうプロンプトが投げられているかの透明性や機構とかが若干無い感じがする。
+    * ccgateだとこれが完全に防げるかというと、履行するAIもなんかい色々回避しようとはするので難しいが、毎回独立して判断しており、プロンプトはある程度透明で、 https://x.com/ryoppippi/status/2044929995743564206 みたいな問題は起こりづらい気がする...?
+* fallthroughもげんなりする気がするので、fallthroughをallow,denyにうわ額機能はいれてあるので、完全全てを自動化したい人にどうぞ。auto modeの挙動を詳しく知りたい人は、別途公式ドキュメントに書いてあるので詳しく見てみたり、技術書典に記事書いたので読んでね。余談だけど技術書典の本、プロダクト組み込みにおけるプロンプトチューニングの話から、ゴリゴリAI組み込み・ツールの話・最近弊社のイベントスペースでよく開催しているイベントの配信の裏側の話やSlackアプリ開発の話などと、vol1に続いてもりもり盛りだくさんなので良ければ是非手に取ってね。
+
+そのまま公開は不能だけど。最近は、db操作を直接やろうとしてこられたり、uv runとかを判断しきれずにfallthroughしてきたりが発生した（ちゃんと指示を書いておらず方針を決めていなかったため）が、ccgate のmetricsをみてccgate.local.jsonnetに書いたことで自動判定がされ、今はAuto Mode無しに、plan modeまで自動運転化に成功している。
+
+
+`../z/ccgatemetricsfull.md`
+1日に50-多い時200もPermission許可/拒否をしていたと見られるペースで、ccgateが走っていて、denyもちゃんとしてくれている。

--- a/articles/20260427-ccgate.md
+++ b/articles/20260427-ccgate.md
@@ -9,7 +9,7 @@ publication_name: layerx
 
 ## はじめに
 
-こんにちは。[@tak848](https://github.com/tak848)です。
+こんにちは。[@tak848](https://github.com/tak848)です。明日が誕生日で、もう25になろうとしています。なんか時が早すぎて困ります。
 みなさん、Coding Agentは使っていますか？個人的には個人でも業務でもClaude Code・Codex CLIと合わせて欠かせないツールになっています。
 
 では、みなさん、Coding Agentが実行するToolのPermission管理はどうしていますか？
@@ -38,7 +38,7 @@ https://github.com/tak848/dotfiles/pull/512
 https://github.com/tak848/ccgate
 
 Auto Modeと、作成当時のpermission hookによる自動許可ツールの設計思想は、先日の技術書典20で出版したLayerX Tech Book Vol.2の中で詳しく解説しています。よければこちらも是非ご覧ください。
-https://techbookfest.org/event/tbf20
+https://techbookfest.org/product/jbe1zdnjqbb6cHwebRhapn?productVariantID=3VefBkLxtiAHJr1vAHjJMY
 
 
 ## Auto Modeとは何が違うのか
@@ -65,6 +65,8 @@ Auto Modeは、Claude Codeの動作
     * （ここ最近の出来事）祝Opus4.7リリース&Auto Mode全解禁！となったものの、これModeとして独立している以上、PlanではPermission地獄から全く抜け出していない。しかも、Auto Modeもruleは設定できるし、というかccgateはもともとauto mode辺りから着想を得て作ったし、カスタマイズもできるが、environmentはなんかdotfiles管理するには絶妙にめんどくさいし、どういうプロンプトが投げられているかの透明性や機構とかが若干無い感じがする。
     * ccgateだとこれが完全に防げるかというと、履行するAIもなんかい色々回避しようとはするので難しいが、毎回独立して判断しており、プロンプトはある程度透明で、 https://x.com/ryoppippi/status/2044929995743564206 みたいな問題は起こりづらい気がする...?
 * fallthroughもげんなりする気がするので、fallthroughをallow,denyにうわ額機能はいれてあるので、完全全てを自動化したい人にどうぞ。auto modeの挙動を詳しく知りたい人は、別途公式ドキュメントに書いてあるので詳しく見てみたり、技術書典に記事書いたので読んでね。余談だけど技術書典の本、プロダクト組み込みにおけるプロンプトチューニングの話から、ゴリゴリAI組み込み・ツールの話・最近弊社のイベントスペースでよく開催しているイベントの配信の裏側の話やSlackアプリ開発の話などと、vol1に続いてもりもり盛りだくさんなので良ければ是非手に取ってね。
+* codex対応
+  * 正直自分がClaude Codeメインで使っている&Codexはあまり実装をメインでまかせるには個人的には微妙で、Claude側では何も設定していなかったけど、Sandboxを設定しつつもnetworkは全許可して、 
 
 そのまま公開は不能だけど。最近は、db操作を直接やろうとしてこられたり、uv runとかを判断しきれずにfallthroughしてきたりが発生した（ちゃんと指示を書いておらず方針を決めていなかったため）が、ccgate のmetricsをみてccgate.local.jsonnetに書いたことで自動判定がされ、今はAuto Mode無しに、plan modeまで自動運転化に成功している。
 

--- a/articles/20260427-ccgate.md
+++ b/articles/20260427-ccgate.md
@@ -1,75 +1,223 @@
 ---
-title: "Claude CodeのPermission許可が大変すぎてccgateというツールを作ったら幸せになった"
+title: "Coding AgentのPermission許可が大変すぎてccgateを作ったら幸せになった"
 emoji: "🛂"
-type: "tech" # tech: 技術記事 / idea: アイデア
-topics: ["AI", "Claude Code"]
+type: "tech"
+topics: ["AI", "ClaudeCode", "Codex", "hook"]
 published: false
 publication_name: layerx
 ---
 
 ## はじめに
 
-こんにちは。[@tak848](https://github.com/tak848)です。明日が誕生日で、もう25になろうとしています。なんか時が早すぎて困ります。
-みなさん、Coding Agentは使っていますか？個人的には個人でも業務でもClaude Code・Codex CLIと合わせて欠かせないツールになっています。
+こんにちは。[@tak848](https://github.com/tak848) です。明日が誕生日で、もう 25 になろうとしています。なんか時が早すぎて困ります。
 
-では、みなさん、Coding Agentが実行するToolのPermission管理はどうしていますか？
-基本的にAllow/Deny Listに登録していますか？ただ、&&, ||や$()などを組み合わせたり（要確認）、もはやシェル芸をAgentがし始めると、Claude Codeの解析器（要名称確認）がAllow List, Deny Listに一致したコマンドの組み合わせだけだとしても、安全のため人間へのPermission許可を求めてくることがあります。
-では、面倒だからDangerously Approveしていないですか？ここ数ヶ月でさまざまなセキュリティインシデントを見かける中で、何のハーネスも無く各toolを実行させるのは怖すぎる気がします。
-3月にClaude CodeではPermission 許可を
+みなさん、Coding Agent は使っていますか。個人的には個人でも業務でも、Claude Code や Codex CLI と並んで欠かせないツールになっています。
 
+ところで、Coding Agent が実行する Tool の Permission 管理ってどうしていますか。毎回出てくる確認プロンプトを 1 つずつ捌いていると、放置して戻ってきたら全然進んでなくてげんなり、ということはないでしょうか。
 
-<!-- みなさん、Coding Agentは使っていますか？この記事を読んでいる多くの人が使っているのでは無いかなと思います。
-色々な開発手法・ツールが出ていると思います。
-では、指示以外に何か困ることありませんか？
-Dangerously Approveをしている？ -->
+タイトルでは「Coding Agent」と書きましたが、本記事で扱うのは Claude Code と、ccgate v0.6 から実験対応した OpenAI Codex CLI です。Cursor や Cline などは対象外です。Permission 許可問題を解決するために作った [ccgate](https://github.com/tak848/ccgate) というツールを紹介します。
 
-## きっかけ
+## Permission 許可、辛くないですか
 
+Coding Agent の Permission 許可、こんな場面で止まりませんか。
 
-もともと、このツールを作ったきっかけは、Claude CodeのAuto Modeが出たことがきっかけでした。ただ、Auto Modeは半日ほど使えるようになったタイミングで、急に業務が高速に進むようになり、感動した記憶があります。
-ただ、すぐに使えなくなってしまい、またPermission許可の嵐に舞い戻されてしまい、なんで使えなくなったんだろう...と思っていました。
+シェル芸でパーサーが詰まるケース。Agent が `$()` のサブシェルや `&&`、`for` ループを組み合わせたコマンドを生成すると、allow/deny の静的パターンマッチが解釈しきれず、毎回確認プロンプトが出ます。allow に登録済みのコマンドでも、組み立て方次第で止まります（筆者の観測）。
 
-しばらく経って、Teamなどの一部のPlanのユーザーに解禁されたとの情報が出ましたが、自身が使用しているMaxやEnterpriseでは依然として使えないままで、これずっと使えないままでは...となりました。
-Auto Modeは調べると、ざっくり言うと、Deny/Allow Listの判定で判定しきれなかったコマンドを、第三者としてのAIがjudgeを行いハンドリングするモードとわかりました。
-そこで、もしかして、前からあるHookの機能を使えば、自分でAuto Modeを作れてしまうのでは？と思い、自身のdotfiles上に実装してみたところ、幸せになりました。
+worktree 跨ぎで延々検索しに行くケース。`myproject` から worktree で `myproject-feat1` を切って作業しているとき、Agent が `myproject/` 側のファイルを読もうとして毎回確認プロンプトが出ます。No を押しても別のパスで再挑戦してきて、また確認。作業が止まります。
+
+allow にも deny にも入っていない gh / db 操作。`gh api` や `psql` の直接実行など、グレーゾーンの操作が多すぎて、結局毎回確認することになります。
+
+プロジェクトの task runner を無視するケース。`make gen` のようなコード生成コマンドがあるのに、Agent が直接ファイル生成しようとする。同じコメントを何度も書く羽目になります。
+
+「じゃあ `--dangerously-skip-permissions` で全部開放？」 — 怖すぎます。最近のセキュリティインシデントを見ていると、何のハーネスもなく各 Tool を実行させるのは厳しい。全部聞くか全部通すかの二択ではなく、**文脈を理解して判断してほしい**わけです。
+
+## Auto Mode だけでは埋まらない隙間
+
+2026 年 3 月、Anthropic から Auto Mode の予告が出ました。LLM ベースの Classifier がリアルタイムに権限判定を行い、確認プロンプトなしで Agent を自律的に動かし続ける仕組みです。
+
+https://claude.com/blog/auto-mode
+
+3 月の半ば、Max でも一瞬だけ使えて、確認プロンプトがなめらかに消える体験に感動しました。しかしすぐに使えなくなり、当時は Team プラン向けの research preview に絞られていました。
+
+そして 4 月 16 日、Opus 4.7 公開と同時に Max ユーザー向けにも research preview が告知されました。これでやっと…と思いきや、[公式ドキュメント](https://code.claude.com/docs/en/permission-modes) を読み直すと、まだ制約が残っています。
+
+- **Pro は対象外**
+- **Max では Opus 4.7 のみ**（モデル選択不可）
+- **Classifier はサーバ側構成のモデル**（自分で選べない、内部はブラックボックス）
+- **Plan モードと Auto Mode は別モード**で、同時には使えない
+
+Max でも Auto Mode は使えるようになりましたが、Plan モードで作業したいとき、Pro 環境で動かしたいとき、判定モデルをカスタマイズしたいとき、Permission 許可地獄は依然として残ったままです。
+
+そういえば 3 月の Auto Mode 一瞬体験のあと、自分の dotfiles に試作の permission hook を入れていました。「Auto Mode の中でやってる LLM 判定なら、Hook で自分で組めるのでは」と気付いたのがきっかけです。
+
 https://github.com/tak848/dotfiles/pull/512
 
-ちょっと使っているうちに、これは便利だとすぐ気づき、社内の技術書典の執筆期限が迫る中で、このHITLを自動化するAuto Modeの思想から、このPermissionHookを実装してみた話を書き上げ、そのタイミングでPermission Hookとして切り出したのがccgateというツールになります。
-https://github.com/tak848/ccgate
+dotfiles の中で動かしていたコードを切り出して、ツールとして仕上げたのが ccgate です。
 
-Auto Modeと、作成当時のpermission hookによる自動許可ツールの設計思想は、先日の技術書典20で出版したLayerX Tech Book Vol.2の中で詳しく解説しています。よければこちらも是非ご覧ください。
+## ccgate は何をするのか
+
+やることは 1 つだけです。
+
+- Claude Code / Codex CLI の `PermissionRequest` フックとして動き、LLM に **allow / deny / fallthrough** の三値を判定させる
+
+ルールは jsonnet に **自然言語で書きます**。Auto Mode の設計を踏襲しています。
+
+```
+Claude Code / Codex CLI (PermissionRequest hook)
+  │  stdin: HookInput JSON
+  ▼
+ccgate
+  ├── 設定（jsonnet）読み込み
+  ├── コンテキスト構築（git/worktree、参照パス、直近の会話履歴）
+  ├── Claude Haiku API（Structured Output）に投げる
+  └── stdout: allow / deny / fallthrough を返す
+```
+
+判定モデルはデフォルトで Haiku 4.5 です。Sonnet や Opus も指定できますが、Haiku で十分判定できます。
+
+### なぜ PermissionRequest フックなのか
+
+Claude Code の hook には PreToolUse もありますが、PermissionRequest を選んでいます。理由は単純で、PermissionRequest は **静的な deny / allow ルールで解決できなかったグレーゾーンだけ** が流れてくるからです。PreToolUse だと全ツール呼び出しを自前で判定する必要があり、LLM 呼び出しのコストとレイテンシが余計にかかります。
+
+### deny に理由を添えるのがミソ
+
+ccgate は deny を返すとき、必ずメッセージを添えます。たとえば worktree 跨ぎを deny するときは「ワークツリー外のチェックアウトにアクセスしようとしています。ワークツリー内のパスを使用してください」と返します。
+
+このメッセージがあると、Agent は理由を理解して別の手段に切り替えます。理由なしに block すると、同じ操作を別の角度からリトライし続けて無限ループになります。
+
+## 使ってみる
+
+インストールは mise が推奨です（mise `2026.4.20` 以降）。
+
+```bash
+mise use -g aqua:tak848/ccgate
+```
+
+aqua（registry `v4.498.0` 以降）でも、go install でも入ります。
+
+```bash
+aqua g -i tak848/ccgate
+# または
+go install github.com/tak848/ccgate@latest
+```
+
+フックを Claude Code に登録します。`~/.claude/settings.json` に書きます。
+
+```json
+{
+  "hooks": {
+    "PermissionRequest": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ccgate claude"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+API キーを `CCGATE_ANTHROPIC_API_KEY` または `ANTHROPIC_API_KEY` にセットします。これだけで内蔵デフォルトルールが効きます。
+
+カスタムしたければ jsonnet を吐き出して編集します。
+
+```bash
+ccgate claude init > ~/.claude/ccgate.jsonnet
+```
+
+たとえば worktree 跨ぎを deny し、draft PR 以外の PR 作成は fallthrough にするルールはこんな感じです。
+
+```jsonnet
+{
+  deny: [
+    'Sibling Checkout / Worktree Confusion: When is_worktree is true, '
+      + 'any access to paths under primary_checkout_root MUST be denied. '
+      + 'deny_message: ワークツリー外のパスにアクセスしようとしています。',
+  ],
+  allow: [
+    'Draft PR Creation: draft=true なら allow、それ以外は fallthrough。',
+  ],
+}
+```
+
+ルールは LLM が自然言語として読みます。パターンマッチでは表現しづらい文脈依存の判断を、LLM に委ねる設計です。
+
+### `fallthrough_strategy`：止めずに走らせたい人へ
+
+ccgate の判定値は allow / deny / **fallthrough** の三値です。fallthrough は「LLM が判断しきれなかった」ということで、デフォルトでは upstream の確認プロンプトに戻します。これが HITL（Human-in-the-Loop）の前提なら良いのですが、bot や Scheduler で完全自動化したいときは止まってしまいます。
+
+`fallthrough_strategy` で挙動を変えられます。
+
+- `ask`（既定）: upstream のプロンプトに戻す
+- `deny`: 強制 deny。「再質問するな・回避策を取るな」のメッセージ付きで拒否として処理させ、許可待ちで止めません（タスク成功は保証しないが、止まらない方を優先したい人向け）
+- `allow`: 強制 allow。リスキー。`decision.message` が AI に届くのは deny のときだけなので、強制 allow 時は AI に何も警告が届かない点に注意
+
+メトリクスの `F.Allow` / `F.Deny` 列で、強制 allow / deny が何回発火したか監査できます。
+
+## どれくらい裁いてくれるか
+
+`ccgate claude metrics` で集計が見られます。私の最近 7 日の使用例。
+
+```
+ccgate metrics (last 7 days)
+Data range: 2026-04-21 ~ 2026-04-27
+
+Date       Total Allow Deny Fall F.Allow F.Deny Err  Auto% Avg(ms) Tokens(in /   out)
+2026-04-27     9     9    0    0       0      0   0 100.0%   3,017    41,543 /    779
+2026-04-26    62    51    9    2       0      0   0  96.8%   3,226   304,591 /  7,195
+2026-04-25    50    42    4    4       0      0   0  92.0%   3,407   302,555 /  5,582
+2026-04-24   201   175   15   10       0      0   1  94.5%   3,094   990,064 / 21,751
+2026-04-23    22    21    1    0       0      0   0 100.0%   3,213   147,859 /  2,453
+2026-04-22   224   188   26    7       0      1   3  95.5%   3,348 1,167,232 / 23,337
+2026-04-21    82    60    9    8       0      1   5  84.1%   2,992   414,492 /  8,256
+
+Automation rate: 93.8% ((allow+deny) / total)
+```
+
+1 日に 50-200 件、平均自動化率 93.8%。Haiku なので運用コストは月数百円〜程度の体感です（具体額は概算）。
+
+fallthrough したコマンドは `--details` オプションで具体例が見られます。
+
+```bash
+ccgate claude metrics --details 5
+```
+
+「あ、このパターンはルール追加すればいけるな」と判断して `ccgate.jsonnet` に書き足す、という育成感のある運用ループができます。
+
+社内で使ってくれる人も増えてきました。自宅 Scheduler で Claude Code を回していて Permission 待ちで止まる問題に困っていた人が「これでいけそう」と反応してくれました。ゆるめのルールで導入する人もいれば、似た仕組みを社内 main に入れた人もいて、意外と波及しているようです。
+
+## Auto Mode / Codex CLI との使い分け
+
+Auto Mode と ccgate の比較を表にしてみます。
+
+|  | Claude Code Auto Mode | ccgate |
+| --- | --- | --- |
+| 利用条件 | Max / Team / Enterprise / API（Pro 不可、Bedrock/Vertex/Foundry 不可） | Claude Code / Codex CLI の hook が使える環境。Anthropic API key 必須 |
+| 判定モデル | サーバ側構成のモデル（自分で選べない） | Haiku デフォルト、Sonnet / Opus も指定可 |
+| 判定値 | allow / block の二値 | allow / deny / **fallthrough** の三値 + `fallthrough_strategy` |
+| 透明性 | ブラックボックス | ルールは jsonnet で見える、ログ・メトリクスで判定結果を追える |
+| Plan モード | Auto Mode は別モードで同時不可 | PermissionRequest hook として動く（Plan mode 判定は prompt 依存で既知課題あり、[#37](https://github.com/tak848/ccgate/issues/37)） |
+
+ccgate には fallthrough という第三の選択肢があるのが大きいと思っています。LLM が「判断つかない」と言ってきたとき、ユーザーに聞きにいくか、強制 deny で進めるか、強制 allow で通すか、選べる。
+
+v0.6 から `ccgate codex` サブコマンドで Codex CLI も同じ仕組みで守れるようになりました。実験的扱いで、Linux/macOS でのみテスト済です。Codex 側の hooks 自体も OpenAI で feature flag 配下なので、仕様変更の可能性もあります。Codex 派の人もぜひ。
+
+「Auto Mode が使える環境ならそれで良い」という温度感です。ccgate と排他でもないですし、両方併用もできます。
+
+書籍の宣伝になります。Auto Mode の中身（Classifier の段階フィルタ、`soft_deny` の挙動、デフォルトルール詳細）は技術書典 Vol.2 で書いた章にあります。
+
 https://techbookfest.org/product/jbe1zdnjqbb6cHwebRhapn?productVariantID=3VefBkLxtiAHJr1vAHjJMY
 
+## おわりに
 
-## Auto Modeとは何が違うのか
+ccgate を使うようになって、Permission 許可で止まる場面がぐっと減りました。`bypassPermissions` で全部開放するのと違って、ルールに沿った行動に Agent を矯正しつつ、安全な操作は自動で通せます。生産性が上がって、危険も増えません。
 
-Auto Modeは、Claude Codeの動作
+既知の課題もあります。設定階層の対称化（[#38](https://github.com/tak848/ccgate/issues/38)）、Plan mode 検出の堅牢化（[#37](https://github.com/tak848/ccgate/issues/37)）あたりが直近の宿題です。PR / issue 歓迎です。
 
+https://github.com/tak848/ccgate
 
-
-
-
-
-
-
-
-
------------------
-
-* 原点は、permission許可/拒否ばっかしてて、なんか生産性がすごく低い。特に放置して戻ってきたときに全然進まず止まっているとげんなりする。思い返すと、代替、シェル芸してきて安全に倒してPermission許可求めてくるケース、worktree跨いで検索し始めて、無限にPermission許可求めてくるケース、allowにもdenyにもそもそも入れていない、db操作を直接行おうとしてくるなどの、AIが本来のプロジェクトに用意・定義されたtask runnerを回せばよいのに迷子になっているケースなど色々ある。そのたびに、このworktreeを調べれば良いじゃん何でもとのほうみにいくの？とか、make/task/mise runとか, pnpm runとかすれば良いよ？みたいな同じようなコメントしたりsuru
-* そして、githubのread系のコマンドは基本自動許可しているものの、gh apiとかみたいなコマンドはallow listに入れて許可は決してしたくない。また他にも、draft PR作成以外は許可したくない、とかもある。github mcpを使うように指示してから、review comment取得とかはmcp経由でallow listに入れると言った回避は出来るようになったが、ghじゃないとできないことも多く、そうすると、allowにも入れず, denyにも入れずで、permission地獄がスタートする。ただ、本来ちゃんとcommandを見れば判断は簡単にできるはず。
-* plan modeなどでのExplore Agentが、高度なシェル芸（$()や&&, ||など）を駆使してコードベースを検索してくるせいで、Claude Codeの解析器が、Allow/Deny Listに登録しているコマンドの組み合わせだけだとしても、Permission許可を求めてくることがある。さらに、そもそも/path/to/reponame-worktree1のような環境で作業しているのに、/path/to/reponameのような本repositoryのパスを検索し始めて、無限にPermission許可を求めてくることがある。
-* 意図しないツール操作をし始める（npx, db操作、プロジェクト定義のtaskを使わない独自コマンド実行、意味も無くcdしてから各操作をしてくるなど）。そもそもallowにもdenyにも登録していないので結果的にPermission許可を求めてきては、同じようなコメントで拒否している
-であれば、その辺を言語化してLLMに判断させて自動で返信させればええやん。少なくとも、作業履行で頭いっぱいのAgentと違って、第三者のLLM callとして呼べば、冷静かつ無慈悲にdenyはしてくれるし、messageも付与して、agentへの理解も促すことができるやん。
-* Auto Mode使えるようになってくれや。ruleを自分でも設定できるみたいだし。
-    * （ここ最近の出来事）祝Opus4.7リリース&Auto Mode全解禁！となったものの、これModeとして独立している以上、PlanではPermission地獄から全く抜け出していない。しかも、Auto Modeもruleは設定できるし、というかccgateはもともとauto mode辺りから着想を得て作ったし、カスタマイズもできるが、environmentはなんかdotfiles管理するには絶妙にめんどくさいし、どういうプロンプトが投げられているかの透明性や機構とかが若干無い感じがする。
-    * ccgateだとこれが完全に防げるかというと、履行するAIもなんかい色々回避しようとはするので難しいが、毎回独立して判断しており、プロンプトはある程度透明で、 https://x.com/ryoppippi/status/2044929995743564206 みたいな問題は起こりづらい気がする...?
-* fallthroughもげんなりする気がするので、fallthroughをallow,denyにうわ額機能はいれてあるので、完全全てを自動化したい人にどうぞ。auto modeの挙動を詳しく知りたい人は、別途公式ドキュメントに書いてあるので詳しく見てみたり、技術書典に記事書いたので読んでね。余談だけど技術書典の本、プロダクト組み込みにおけるプロンプトチューニングの話から、ゴリゴリAI組み込み・ツールの話・最近弊社のイベントスペースでよく開催しているイベントの配信の裏側の話やSlackアプリ開発の話などと、vol1に続いてもりもり盛りだくさんなので良ければ是非手に取ってね。
-* codex対応
-  * 正直自分がClaude Codeメインで使っている&Codexはあまり実装をメインでまかせるには個人的には微妙で、Claude側では何も設定していなかったけど、Sandboxを設定しつつもnetworkは全許可して、 
-
-そのまま公開は不能だけど。最近は、db操作を直接やろうとしてこられたり、uv runとかを判断しきれずにfallthroughしてきたりが発生した（ちゃんと指示を書いておらず方針を決めていなかったため）が、ccgate のmetricsをみてccgate.local.jsonnetに書いたことで自動判定がされ、今はAuto Mode無しに、plan modeまで自動運転化に成功している。
-
-
-`../z/ccgatemetricsfull.md`
-1日に50-多い時200もPermission許可/拒否をしていたと見られるペースで、ccgateが走っていて、denyもちゃんとしてくれている。
+25 歳になる前に、Permission 許可ボタンを 25 回どころか 50 回も 100 回も押す生活からは抜け出せました。みなさんもよければお試しください。

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,md}\""
+    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,md}\"",
+    "lint": "textlint",
+    "lint:fix": "textlint --fix"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary

- ccgate を Zenn で紹介する記事のドラフトを追加 (`articles/20260427-ccgate.md`)。`published: false` で公開はユーザー手動。
- 8 章構成: はじめに / Permission 許可の辛さ / Auto Mode の隙間 / ccgate の動き / 使い方 + `fallthrough_strategy` / メトリクス / Auto Mode・Codex CLI との使い分け / おわりに。
- 公開タイミングは ccgate v0.6 リリース後を想定（README が既に v0.6 前提のため）。
- `package.json` に textlint 用 `lint` / `lint:fix` scripts を追加（引数で対象ファイル指定）。

## Verification

- `pnpm run lint articles/20260427-ccgate.md` エラーゼロ
- 禁止語 grep（実現する / 思想 / シナジー / 重要な一歩 / 未来に向けて 等）ヒットなし
- 文字数 7900 字（frontmatter とコードブロック含む、本文 5500-6500 字目安）
- ccgate README v0.6 ベースでコマンド・パス・環境変数を確認
- Auto Mode の利用条件・モデル制約は [公式 docs](https://code.claude.com/docs/en/permission-modes) で確認済（Pro 不可、Max は Opus 4.7 のみ、Classifier はサーバ側構成）

## TODO

- [ ] codex-review-cycle で執筆物の最終レビュー
- [ ] v0.6 リリース後、メトリクス出力を `ccgate claude metrics` で再取得して redaction 後に貼り直す
- [ ] Zenn プレビューで表示確認 (`pnpm exec zenn preview`)
- [ ] 公開可否最終判断 → `published: true` に変更して公開

## Notes

- 執筆プランは `.claude/plans/layerxcom-techbook2-contents-tak848-md-luminous-wirth.md`（commit 対象外）にあり、Codex によるプランレビューを 2 ラウンド実施済み。
- 書籍（技術書典 Vol.2）からのコピーは禁止し、誘導は記事中 1 回のみ。

(by Claude Code)