### PR TITLE
docs: add inline brief for Auto Mode on first mention

### DIFF
--- a/articles/20260428-ccgate.md
+++ b/articles/20260428-ccgate.md
@@ -26,7 +26,7 @@ publication_name: layerx
 
 https://github.com/tak848/ccgate
 
-元々ccgateは、Claude CodeのAuto Modeがまだ手元で使えなかったころに、Auto Mode的な体験を目指して作り始めたものです。その後Auto Modeは自分の環境でも使えるようになりましたが、それでもccgateを外していません。使ってみると、ccgateがないと普通に困る場面が残っていたからです。Auto Modeとの棲み分けは後ろで書きます。
+元々ccgateは、Claude CodeのAuto Mode(Permission確認を別のclassifierに任せるpermission mode)がまだ手元で使えなかったころに、Auto Mode的な体験を目指して作り始めたものです。その後Auto Modeは自分の環境でも使えるようになりましたが、それでもccgateを外していません。使ってみると、ccgateがないと普通に困る場面が残っていたからです。Auto Modeとの棲み分けは後ろで書きます。
 
 ## ccgateでできること
 


### PR DESCRIPTION
## Summary

「はじめに」でAuto Modeが初出するL29に、jsonnet初出時(L51)と同様の括弧付き短い説明を入れる。

```diff
- 元々ccgateは、Claude CodeのAuto Modeがまだ手元で使えなかったころに、
+ 元々ccgateは、Claude CodeのAuto Mode(Permission確認を別のclassifierに任せるpermission mode)がまだ手元で使えなかったころに、
```

詳しい説明は後続の「Auto Modeとの棲み分け」節に既にあるので、ここでは1行の概要のみ。

## Test plan

- [ ] Zennプレビューで該当行が崩れずレンダリングされるか確認

(by Claude Code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/zenn-contents/pull/28" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
